### PR TITLE
Add sample dry bulk webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # sandbox
+
 testing gihub integration and stuff
+
+## Dry Bulk Webapp
+
+Open `index.html` in a browser to view sample cargos. Right-click a cargo and choose **Suitable Ships** to open the Ship ETA page. The Ship ETA page pre-filters ships by the cargo's load port and sets the laycan filter to five days before the cargo's laycan. Ships arriving before the laycan are shown in red.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dry Bulk Cargoes</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        ul { list-style-type: none; padding: 0; }
+        li { padding: 8px; border: 1px solid #ccc; margin-bottom: 5px; cursor: context-menu; }
+        #context-menu { position: absolute; background: #fff; border: 1px solid #999; display: none; z-index: 1000; }
+        #context-menu div { padding: 8px; cursor: pointer; }
+        #context-menu div:hover { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>Cargo List</h1>
+    <ul id="cargo-list"></ul>
+
+    <div id="context-menu"><div id="suitable-ships">Suitable Ships</div></div>
+
+    <script>
+        // Sample cargo data
+        const cargos = [
+            { id: 1, description: 'Iron Ore', loadPort: 'Port Hedland', laycan: '2023-09-15' },
+            { id: 2, description: 'Coal', loadPort: 'Richards Bay', laycan: '2023-09-20' },
+            { id: 3, description: 'Grain', loadPort: 'New Orleans', laycan: '2023-09-25' }
+        ];
+
+        const cargoList = document.getElementById('cargo-list');
+
+        cargos.forEach(cargo => {
+            const li = document.createElement('li');
+            li.textContent = `${cargo.description} - ${cargo.loadPort} - Laycan: ${cargo.laycan}`;
+            li.dataset.loadPort = cargo.loadPort;
+            li.dataset.laycan = cargo.laycan;
+            cargoList.appendChild(li);
+        });
+
+        // Context menu logic
+        const contextMenu = document.getElementById('context-menu');
+        let selectedCargo = null;
+
+        document.addEventListener('click', () => {
+            contextMenu.style.display = 'none';
+        });
+
+        cargoList.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            const target = e.target.closest('li');
+            if (!target) return;
+            selectedCargo = target;
+            contextMenu.style.top = `${e.pageY}px`;
+            contextMenu.style.left = `${e.pageX}px`;
+            contextMenu.style.display = 'block';
+        });
+
+        document.getElementById('suitable-ships').addEventListener('click', () => {
+            if (!selectedCargo) return;
+            const loadPort = selectedCargo.dataset.loadPort;
+            const laycan = selectedCargo.dataset.laycan;
+            window.location.href = `ship_eta.html?loadPort=${encodeURIComponent(loadPort)}&laycan=${encodeURIComponent(laycan)}`;
+        });
+    </script>
+</body>
+</html>

--- a/ship_eta.html
+++ b/ship_eta.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Ship ETA</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        .early { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Suitable Ships</h1>
+    <div id="filters"></div>
+    <table>
+        <thead>
+            <tr><th>Ship</th><th>Load Port</th><th>ETA</th></tr>
+        </thead>
+        <tbody id="ship-list"></tbody>
+    </table>
+
+    <script>
+        // Parse query parameters
+        const params = new URLSearchParams(window.location.search);
+        const loadPort = params.get('loadPort');
+        const laycanStr = params.get('laycan');
+        const laycanDate = new Date(laycanStr);
+        const filterLaycan = new Date(laycanDate);
+        filterLaycan.setDate(filterLaycan.getDate() - 5);
+
+        // Sample ship data
+        const ships = [
+            { name: 'MV Alpha', loadPort: 'Port Hedland', eta: '2023-09-10' },
+            { name: 'MV Beta', loadPort: 'Port Hedland', eta: '2023-09-16' },
+            { name: 'MV Gamma', loadPort: 'Richards Bay', eta: '2023-09-18' },
+            { name: 'MV Delta', loadPort: 'New Orleans', eta: '2023-09-22' }
+        ];
+
+        document.getElementById('filters').textContent = `Load Port: ${loadPort} | Laycan: ${filterLaycan.toISOString().split('T')[0]}`;
+
+        const shipList = document.getElementById('ship-list');
+        ships.filter(ship => ship.loadPort === loadPort && new Date(ship.eta) >= filterLaycan)
+            .forEach(ship => {
+                const tr = document.createElement('tr');
+                if (new Date(ship.eta) < laycanDate) {
+                    tr.classList.add('early');
+                }
+                tr.innerHTML = `<td>${ship.name}</td><td>${ship.loadPort}</td><td>${ship.eta}</td>`;
+                shipList.appendChild(tr);
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` with cargo list and context menu linking to a pre-filtered ship ETA page.
- Create `ship_eta.html` to filter ships by load port and laycan minus five days and highlight early arrivals.
- Document usage in README.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be948e7a8c83278b1897e805507ca0